### PR TITLE
ci: add workflow for PR semantic check

### DIFF
--- a/.github/workflows/semantic-pull-requests.yaml
+++ b/.github/workflows/semantic-pull-requests.yaml
@@ -1,6 +1,11 @@
 name: "Lint PR"
 
-on:  workflow_call
+on:
+  workflow_call:
+    secrets:
+      GIT_HUB_PAT:
+        description: "GitHub Personal Access Token for authentication"
+        required: true
 
 permissions:
   pull-requests: write
@@ -14,4 +19,4 @@ jobs:
         with:
           wip: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GIT_HUB_PAT }}


### PR DESCRIPTION
We want to use https://github.com/amannn/action-semantic-pull-request, it's used by a lot of larger repos on Github.
The configuration is pretty simple, as stated on their own page, does not require particular input variables.

There obviously are parameters that we could want to explore at a later stage, or when the need arises, see: https://github.com/amannn/action-semantic-pull-request/blob/main/action.yml

## Squash PRs
We should imho align with what  https://github.com/amannn/action-semantic-pull-request repo states, that is:
> If your goal is to create squashed commits that will be used for automated releases, you'll want to configure your GitHub repository to [use the squash & merge strategy](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) and tick the option "Default to PR title for squash merge commits".

## WIP pull requests
> For work-in-progress PRs you can typically use [draft pull requests from GitHub](https://github.blog/2019-02-14-introducing-draft-pull-requests/). However, private repositories on the free plan don't have this option and therefore this action allows you to opt-in to using the special "[WIP]" prefix to indicate this state.
>
>Example:
>
>[WIP] feat: Add support for Node.js 18
>This will prevent the PR title from being validated, and pull request checks will remain pending.
