### PR TITLE
fix: remove permission to inherit the main GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/semantic-pull-requests.yaml
+++ b/.github/workflows/semantic-pull-requests.yaml
@@ -7,9 +7,6 @@ on:
         description: "GitHub Personal Access Token for authentication"
         required: true
 
-permissions:
-  pull-requests: write
-
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
As title. Adding permissions actually does not add the permission itself but create a new token with only the defined permissions.
By removing permissions it should inherit the main token