### PR TITLE
ci: dockerhub syncing with repo readme

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -26,6 +26,16 @@ on:
         required: false
         type: 'string'
         default: 'Dockerfile'
+      dockerhub_shortdesc:
+        description: 'Short description for DockerHub repository'
+        required: false
+        type: 'string'
+        default: 'Radicalbit AI Monitoring'
+      dockerhub_enable_url_completion:
+        description: 'Whether we should enable completion of relative URLs to absolute ones'
+        required: false
+        type: 'boolean'
+        default: true
     secrets:
       USERNAME:
         description: 'Registry username'
@@ -66,3 +76,12 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ secrets.ORGANIZATION }}/${{ inputs.image }}:${{ inputs.tag }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          repository: ${{ secrets.ORGANIZATION }}/${{ inputs.image }}
+          short-description: ${{ inputs.dockerhub_shortdesc }}
+          enable-url-completion: ${{ inputs.dockerhub_enable_url_completion }}


### PR DESCRIPTION
As title, we use the [peter-evans/dockerhub-description](https://github.com/peter-evans/dockerhub-description) github action to automatically sync the DockerHub description with github repo's README.md.

Some details:

* We'll allow to pass a "short" description that could be different for every component of the platform
* We allow to convert relative URLs to absolute ones, as the action can do it for us