### PR TITLE
fix(ci): removed default running directory, fix template name

### DIFF
--- a/.github/workflows/trivy-fs-scan.yaml
+++ b/.github/workflows/trivy-fs-scan.yaml
@@ -39,9 +39,6 @@ jobs:
   run-scan:
     name: Run Trivy vulnerability scanner
     runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: ${{ inputs.directory }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,11 +53,12 @@ jobs:
           scan-type: 'fs'
           ignore-unfixed: true
           format: 'template'
-          template: 'trivy-pr-comment.tpl'
+          template: '@trivy-pr-comment.tpl'
           output: 'trivy.json'
           severity: ${{ inputs.severity }}
           skip-dirs: ${{ inputs.skip_dirs }}
           exit-code: ${{ inputs.prcomment && '1' || '0' }}
+          scan-ref: '${{ inputs.directory }}'
 
       - name: Report vulnerabilities in PR
         if: ${{ inputs.prcomment && failure() && steps.scan.outcome == 'failure' }}


### PR DESCRIPTION
As title, this should fix errors in triv vulnerability scan workflow. Follow a new release