### PR TITLE
chore: bump trivy action version

### DIFF
--- a/.github/workflows/trivy-fs-scan.yaml
+++ b/.github/workflows/trivy-fs-scan.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         id: scan
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
As title, we bump the action version from `0.20.0` to `0.28.0`