### PR TITLE
fix: bump trivy action

### DIFF
--- a/.github/workflows/trivy-fs-scan.yaml
+++ b/.github/workflows/trivy-fs-scan.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         id: scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
Bump trivy action because 0.28.0 isn't available anymore